### PR TITLE
fix utf-8 support for fetching

### DIFF
--- a/contrib/remote-helpers/git-remote-bzr
+++ b/contrib/remote-helpers/git-remote-bzr
@@ -183,21 +183,24 @@ def get_filechanges(cur, prev):
 
     changes = cur.changes_from(prev)
 
+    def u(s):
+        return s.encode('utf-8')
+
     for path, fid, kind in changes.added:
-        modified[path] = fid
+        modified[u(path)] = fid
     for path, fid, kind in changes.removed:
-        removed[path] = None
+        removed[u(path)] = None
     for path, fid, kind, mod, _ in changes.modified:
-        modified[path] = fid
+        modified[u(path)] = fid
     for oldpath, newpath, fid, kind, mod, _ in changes.renamed:
-        removed[oldpath] = None
+        removed[u(oldpath)] = None
         if kind == 'directory':
             lst = cur.list_files(from_dir=newpath, recursive=True)
             for path, file_class, kind, fid, entry in lst:
                 if kind != 'directory':
-                    modified[newpath + '/' + path] = fid
+                    modified[u(newpath + '/' + path)] = fid
         else:
-            modified[newpath] = fid
+            modified[u(newpath)] = fid
 
     return modified, removed
 
@@ -223,7 +226,7 @@ def export_files(tree, files):
             # is the blog already exported?
             if h in filenodes:
                 mark = filenodes[h]
-                final.append((mode, mark, path.encode('utf-8')))
+                final.append((mode, mark, path))
                 continue
 
             d = tree.get_file_text(fid)
@@ -240,7 +243,7 @@ def export_files(tree, files):
         print "data %d" % len(d)
         print d
 
-        final.append((mode, mark, path.encode('utf-8')))
+        final.append((mode, mark, path))
 
     return final
 

--- a/contrib/remote-helpers/test-bzr.sh
+++ b/contrib/remote-helpers/test-bzr.sh
@@ -177,6 +177,8 @@ test_expect_success 'fetch utf-8 filenames' '
 
   echo test >> "áéíóú" &&
   bzr add "áéíóú" &&
+  bzr commit -m utf-8 &&
+  bzr mv "áéíóú" "åß∂" &&
   bzr commit -m utf-8
   ) &&
 
@@ -186,7 +188,7 @@ test_expect_success 'fetch utf-8 filenames' '
   git ls-files > ../actual
   ) &&
 
-  echo "\"\\303\\241\\303\\251\\303\\255\\303\\263\\303\\272\"" > expected &&
+  echo "\"\\303\\245\\303\\237\\342\\210\\202\"" > expected &&
   test_cmp expected actual
 '
 


### PR DESCRIPTION
the previous fix handled only the addition of utf-8 named files, not the deletion (and renaming)
