### PR TITLE
Ensure git-remote-hg uses python 2

### DIFF
--- a/git-remote-hg.py
+++ b/git-remote-hg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright (c) 2012 Felipe Contreras
 #


### PR DESCRIPTION
Mercurial does not support python 3. By specifying the version of python required for git-remote-hg, we avoid failure on systems that have python 3 as the default version.
