### PR TITLE
remote-bzr: include authors field in bzr commits

### DIFF
--- a/git-remote-bzr.py
+++ b/git-remote-bzr.py
@@ -619,10 +619,12 @@ def parse_commit(parser):
         files[path] = f
 
     committer, date, tz = committer
+    author, _, _ = author
     parents = [mark_to_rev(p) for p in parents]
     revid = bzrlib.generate_ids.gen_revision_id(committer, date)
     props = {}
     props['branch-nick'] = branch.nick
+    props['authors'] = author
 
     mtree = CustomTree(branch, revid, parents, files)
     changes = mtree.iter_changes()


### PR DESCRIPTION
Trivial patch. It's already parsed from the git input, just needed to add it to revprops.

(I needed to remove `.git/bzr/<remote>/` to be able to get this revprop added to commits I pushed before, without this patch)

Having to send this pull request reminds me of this particular part of the [blog post](http://felipec.wordpress.com/2012/11/13/git-remote-hg-bzr-2/) that introduces these helpers:

> So, are there any drawbacks? Surely some information must be lost.
> Nope, not really. At least not when using the hg-git compat mode, because all the extra information is saved in the commit messages.

I knew some day I would find some missing metadata. (But, TBH, other than this detail, it's been wonderful)
