### PR TITLE
Add kind_changed files to commits

### DIFF
--- a/git-remote-bzr.py
+++ b/git-remote-bzr.py
@@ -219,6 +219,8 @@ def get_filechanges(cur, prev):
         modified[u(path)] = fid
     for path, fid, kind in changes.removed:
         removed[u(path)] = None
+    for path, fid, oldkind, newkind in changes.kind_changed:
+        modified[u(path)] = fid
     for path, fid, kind, mod, _ in changes.modified:
         modified[u(path)] = fid
     for oldpath, newpath, fid, kind, mod, _ in changes.renamed:


### PR DESCRIPTION
Previously, a file that changed kind was lost from the commit history. For
example if a file that is a symlink was changed to a regular file containing the
contents of its target or vise-versa, then this change was lost.
